### PR TITLE
fix namevar to be separated from item

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -78,6 +78,7 @@ The value for the item (e.g. 'Europe').
 The following parameters are available in the `debconf` type.
 
 * [`item`](#item)
+* [`name`](#name)
 * [`package`](#package)
 * [`provider`](#provider)
 * [`type`](#type)
@@ -88,7 +89,12 @@ Valid values: `%r{^[a-z0-9][a-z0-9:.+-]+\/[a-zA-Z0-9\/_.+-]+$}`
 
 The item name. This string must have the following format: the
 package name, a literal slash char and the name of the question (e.g.
-'tzdata/Areas').
+'tzdata/Areas'). defaults to the title of the resource
+
+##### <a name="name"></a>`name`
+
+namevar
+
 
 ##### <a name="package"></a>`package`
 

--- a/lib/puppet/type/debconf.rb
+++ b/lib/puppet/type/debconf.rb
@@ -49,11 +49,15 @@ Puppet::Type.newtype(:debconf) do
     defaultto :present
   end
 
-  newparam(:item, namevar: true) do
+  newparam(:name, namevar: true) do
+  end
+
+  newparam(:item) do
     desc "The item name. This string must have the following format: the
       package name, a literal slash char and the name of the question (e.g.
-      'tzdata/Areas')."
+      'tzdata/Areas'). defaults to the title of the resource"
 
+    defaultto { @resource[:name] }
     newvalues(%r{^[a-z0-9][a-z0-9:.+-]+\/[a-zA-Z0-9\/_.+-]+$})
   end
 

--- a/spec/unit/type/debconf_spec.rb
+++ b/spec/unit/type/debconf_spec.rb
@@ -22,7 +22,7 @@ describe Puppet::Type.type(:debconf) do
 
       describe 'namevar validation' do
         it 'has :item as its namevar' do
-          expect(described_class.key_attributes).to eq([:item])
+          expect(described_class.key_attributes).to eq([:name])
         end
       end
     end


### PR DESCRIPTION
under certain circumstances, the same item name is used/defined
on different packages. With this change, this can be done in puppet also.